### PR TITLE
Fixed path separators with windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (rackspace, options) {
 		var isFile = fs.lstatSync(file.path).isFile();
 		if (!isFile) { return false; }
 
-		var uploadPath = file.path.replace(file.base, options.uploadPath || '');
+		var uploadPath = file.path.replace(file.base, options.uploadPath || '').replace('\\','/');
 		var headers = { 'x-amz-acl': 'public-read' };
 		if (options.headers) {
 			for (var key in options.headers) {


### PR DESCRIPTION
This replaces instances of `\\` windows separators with `/` separators so that folder paths get preserved inside the container.

FIxes #2 
